### PR TITLE
delete コマンドの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Usage:
 Available Commands:
   ls                                            List all projects
   add [project name]                            Add project to list
+  delete [project name]                         Delete project from list
   save [project name]                           Save project
   restore [project name]                        Restore project
   help [command]                                Help about any command

--- a/completion/hyena_completion.bash
+++ b/completion/hyena_completion.bash
@@ -5,7 +5,7 @@ _hyena()
   local cur=${COMP_WORDS[COMP_CWORD]}
   case "$COMP_CWORD" in
   1)
-    COMPREPLY=( $(compgen -W "init ls add save restore" -- $cur) );;
+    COMPREPLY=( $(compgen -W "init ls add delete save restore" -- $cur) );;
   2)
     COMPREPLY=( $(compgen -W "$(hyena ls)" -- $cur) );;
   esac

--- a/completion/hyena_completion.fish
+++ b/completion/hyena_completion.fish
@@ -28,11 +28,16 @@ function __fish_hyena_projects
 end
 
 ## hyena
-complete -f -c hyena -n '__fish_hyena_using_command' -a "init ls add save restore"
+complete -f -c hyena -n '__fish_hyena_using_command' -a "init ls add delete save restore"
 
 ## hyena add
 complete -f -c hyena -n '__fish_hyena_using_command add' -a '(__fish_hyena_projects)'
 complete -f -c hyena -n '__fish_hyena_using_command a' -a '(__fish_hyena_projects)'
+
+## hyena delete
+complete -f -c hyena -n '__fish_hyena_using_command delete' -a '(__fish_hyena_projects)'
+complete -f -c hyena -n '__fish_hyena_using_command d' -a '(__fish_hyena_projects)'
+
 
 ## hyena save
 complete -f -c hyena -n '__fish_hyena_using_command save' -a '(__fish_hyena_projects)'

--- a/completion/hyena_completion.zsh
+++ b/completion/hyena_completion.zsh
@@ -13,6 +13,7 @@ __hyena_modes(){
         'init[Initialize hyena (Should be executed only when you installed hyena)]' \
         'ls[List all your projects]' \
         'add[Add a new project]' \
+        'delete[Delete a project]' \
         'save[Save current state to the project]' \
         'restore[Restore project]'
 }

--- a/hyena.go
+++ b/hyena.go
@@ -76,38 +76,44 @@ func hyenaLs(c *cli.Context) {
 	hyenaLogger.Println("finished ls command")
 }
 
-func hyenaAdd(c *cli.Context) {
-	hyenaLogger := logger.GetInstance()
-	hyenaLogger.Println("to run add command")
+func hyenaExecWithProject(c *cli.Context) {
+	cmd := c.Command.Name
 	name := c.Args().First()
+	hyenaLogger := logger.GetInstance()
+	hyenaLogger.Println("to run " + cmd + " command")
 	if name == "" {
 		hyenaLogger.Println("scan empty as input")
 		println("please input project name")
 	} else {
 		hyenaLogger.Println("scan " + name + " as input")
-		pm.Add(configPath, name)
-		println("created new project named " + name)
-		git.Init(path.Join(hyenaPath, name))
+		switch cmd {
+		case "add":
+			hyenaAdd(name)
+		case "delete":
+			hyenaDelete(name)
+		case "save":
+			hyenaSave(name)
+		case "restore":
+			hyenaRestore(name)
+		default:
+			hyenaLogger.Println("cmd not apply any case")
+		}
 	}
-	hyenaLogger.Println("finished add command")
+	hyenaLogger.Println("finished " + cmd + " command")
 }
 
-func hyenaDelete(c *cli.Context) {
-	hyenaLogger := logger.GetInstance()
-	hyenaLogger.Println("to run delete command")
-	name := c.Args().First()
-	if name == "" {
-		hyenaLogger.Println("scan empty as input")
-		println("please input project name")
-	} else {
-		hyenaLogger.Println("scan " + name + " as input")
-		pm.Delete(configPath, name)
-		println("deleted the project named " + name)
-	}
-	hyenaLogger.Println("finished delete command")
+func hyenaAdd(name string) {
+	pm.Add(configPath, name)
+	git.Init(path.Join(hyenaPath, name))
+	println("created new project named " + name)
 }
 
-func save(projectName string) {
+func hyenaDelete(name string) {
+	pm.Delete(configPath, name)
+	println("deleted the project named " + name)
+}
+
+func hyenaSave(projectName string) {
 	projectPath := path.Join(hyenaPath, projectName)
 	chrome.Save(path.Join(projectPath, "chrome.json"))
 	acrobat.Save(path.Join(projectPath, "acrobat.json"))
@@ -116,40 +122,12 @@ func save(projectName string) {
 	git.Commit(projectPath, "hyena auto git commit")
 }
 
-func hyenaSave(c *cli.Context) {
-	hyenaLogger := logger.GetInstance()
-	hyenaLogger.Println("to run save command")
-	name := c.Args().First()
-	if name == "" {
-		hyenaLogger.Println("scan empty as input")
-		println("please input project name")
-	} else {
-		hyenaLogger.Println("scan " + name + " as input")
-		save(name)
-	}
-	hyenaLogger.Println("finished save command")
-}
-
-func restore(projectName string) {
+func hyenaRestore(projectName string) {
 	projectPath := path.Join(hyenaPath, projectName)
 	chrome.Restore(path.Join(projectPath, "chrome.json"))
 	acrobat.Restore(path.Join(projectPath, "acrobat.json"))
 	kobito.Restore(path.Join(projectPath, "kobito.json"))
 	atom.Restore(path.Join(projectPath, "atom.json"))
-}
-
-func hyenaRestore(c *cli.Context) {
-	hyenaLogger := logger.GetInstance()
-	hyenaLogger.Println("to run restore command")
-	name := c.Args().First()
-	if name == "" {
-		hyenaLogger.Println("scan empty as input")
-		println("please input project name")
-	} else {
-		hyenaLogger.Println("scan " + name + " as input")
-		restore(name)
-	}
-	hyenaLogger.Println("finished restore command")
 }
 
 func main() {
@@ -179,22 +157,22 @@ func main() {
 			Name:    "add",
 			Aliases: []string{"a"},
 			Usage:   "add the project",
-			Action:  hyenaAdd,
+			Action:  hyenaExecWithProject,
 		}, {
 			Name:    "delete",
 			Aliases: []string{"d"},
 			Usage:   "delete the project",
-			Action:  hyenaDelete,
+			Action:  hyenaExecWithProject,
 		}, {
 			Name:    "save",
 			Aliases: []string{"s"},
 			Usage:   "save the project",
-			Action:  hyenaSave,
+			Action:  hyenaExecWithProject,
 		}, {
 			Name:    "restore",
 			Aliases: []string{"r"},
 			Usage:   "restore the project",
-			Action:  hyenaRestore,
+			Action:  hyenaExecWithProject,
 		},
 	}
 

--- a/hyena.go
+++ b/hyena.go
@@ -92,6 +92,21 @@ func hyenaAdd(c *cli.Context) {
 	hyenaLogger.Println("finished add command")
 }
 
+func hyenaDelete(c *cli.Context) {
+	hyenaLogger := logger.GetInstance()
+	hyenaLogger.Println("to run delete command")
+	name := c.Args().First()
+	if name == "" {
+		hyenaLogger.Println("scan empty as input")
+		println("please input project name")
+	} else {
+		hyenaLogger.Println("scan " + name + " as input")
+		pm.Delete(configPath, name)
+		println("deleted the project named " + name)
+	}
+	hyenaLogger.Println("finished delete command")
+}
+
 func save(projectName string) {
 	projectPath := path.Join(hyenaPath, projectName)
 	chrome.Save(path.Join(projectPath, "chrome.json"))
@@ -165,6 +180,11 @@ func main() {
 			Aliases: []string{"a"},
 			Usage:   "add the project",
 			Action:  hyenaAdd,
+		}, {
+			Name:    "delete",
+			Aliases: []string{"d"},
+			Usage:   "delete the project",
+			Action:  hyenaDelete,
 		}, {
 			Name:    "save",
 			Aliases: []string{"s"},

--- a/util/pm/projectManager.go
+++ b/util/pm/projectManager.go
@@ -82,3 +82,32 @@ func Add(configPath string, newProject string) {
 		hyenaLogger.Fatalln(err)
 	}
 }
+
+// Delete deletes a project from project list by the path of config file
+func Delete(configPath string, targetProject string) {
+	hyenaLogger := logger.GetInstance()
+	hyenaLogger.Println("to delete " + targetProject + " project")
+
+	_projects := Load(configPath)
+	projects := []string{}
+	for _, name := range _projects {
+		if name != targetProject {
+			projects = append(projects, name)
+		}
+	}
+
+	js := simplejson.New()
+	projectJSON := simplejson.New()
+	for i, v := range projects {
+		projectJSON.Set(strconv.Itoa(i), v)
+	}
+	js.Set("length", len(projects))
+	js.Set("projects", projectJSON)
+	w, err := os.Create(configPath)
+	if err != nil {
+		hyenaLogger.Fatalln(err)
+	}
+	defer w.Close()
+	o, _ := js.EncodePretty()
+	w.Write(o)
+}

--- a/util/pm/projectManager.go
+++ b/util/pm/projectManager.go
@@ -88,11 +88,11 @@ func Delete(configPath string, targetProject string) {
 	hyenaLogger := logger.GetInstance()
 	hyenaLogger.Println("to delete " + targetProject + " project")
 
-	_projects := Load(configPath)
-	projects := []string{}
-	for _, name := range _projects {
-		if name != targetProject {
-			projects = append(projects, name)
+	projects := Load(configPath)
+	for i, name := range projects {
+		if name == targetProject {
+			projects = append(projects[:i], projects[i+1:]...)
+			break
 		}
 	}
 


### PR DESCRIPTION
## Why
- プロジェクトが削除できなかった
## How
- `hyena delete project_name` コマンドの実装
- add/delete/save/resotre など、引数にプロジェクト名をとるコマンドの共通部分を `hyenaExecWithProject` 関数でまとめた
- `README.md` に追記
- `completion` フォルダ内の `bash/zsh/fish` 用のやつにも追記
