### PR TITLE
アプリケーション名をBundle IDで指定

### DIFF
--- a/app/acrobat/acrobat_restore_doc.applescript
+++ b/app/acrobat/acrobat_restore_doc.applescript
@@ -1,7 +1,7 @@
 #!/usr/bin/env osascript -l JavaScript
 
 function acrobat_restore_doc(json_string) {
-    var app = Application('Adobe Acrobat');
+    var app = Application('com.adobe.Acrobat.Pro');
     var data = JSON.parse(json_string);
     var docs = data[0];
 
@@ -14,7 +14,7 @@ function acrobat_restore_doc(json_string) {
 
 function run(argv) {
     try {
-        var app = Application('Adobe Acrobat');
+        var app = Application('com.adobe.Acrobat.Pro');
     } catch (e) {
         console.log(e);
         return false;

--- a/app/acrobat/acrobat_save_doc.applescript
+++ b/app/acrobat/acrobat_save_doc.applescript
@@ -1,7 +1,7 @@
 #!/usr/bin/env osascript -l JavaScript
 
 function acrobat_get_docs_info() {
-    app = Application('Adobe Acrobat');
+    app = Application('com.adobe.Acrobat.Pro');
     var res = {};
     res[0] = [];
 
@@ -16,7 +16,7 @@ function acrobat_get_docs_info() {
 
 function run(argv) {
     try {
-        var app = Application('Adobe Acrobat');
+        var app = Application('com.adobe.Acrobat.Pro');
     } catch (e) {
         console.log(e);
         return false;

--- a/app/chrome/chrome_restore_tab.applescript
+++ b/app/chrome/chrome_restore_tab.applescript
@@ -1,7 +1,7 @@
 #!/usr/bin/env osascript -l JavaScript
 
 function chrome_restore_tabs(json_string) {
-    app = Application('Google Chrome');
+    app = Application('com.google.Chrome');
     var data = JSON.parse(json_string);
     var n_windows = Object.keys(data).length;
 
@@ -24,7 +24,7 @@ function chrome_restore_tabs(json_string) {
 
 function run(argv) {
     try {
-        var app = Application('Google Chrome');
+        var app = Application('com.google.Chrome');
     } catch (e) {
         console.log(e);
         return false;

--- a/app/chrome/chrome_save_tab.applescript
+++ b/app/chrome/chrome_save_tab.applescript
@@ -1,7 +1,7 @@
 #!/usr/bin/env osascript -l JavaScript
 
 function chrome_get_tab_info() {
-    app = Application('Google Chrome');
+    app = Application('com.google.Chrome');
     windows = app.windows();
     var res = {};
 

--- a/app/kobito/kobito_restore_app.applescript
+++ b/app/kobito/kobito_restore_app.applescript
@@ -24,7 +24,7 @@ function open_n_th_item(n) {
 }
 
 function activate_kobito() {
-    var kobito = Application("Kobito");
+    var kobito = Application('com.qiita.Kobito');
     kobito.quit();
     var app = Application.currentApplication();
     app.includeStandardAdditions = true;
@@ -44,7 +44,7 @@ function get_one_title(json_string) {
 
 function run(argv) {
     try {
-        var app = Application('Kobito');
+        var app = Application('com.qiita.Kobito');
     } catch (e) {
         console.log(e);
         return false;

--- a/app/preview/preview_restore_doc.applescript
+++ b/app/preview/preview_restore_doc.applescript
@@ -21,7 +21,7 @@ function preview_restore_doc(json_string) {
 
 function run(argv) {
     try {
-        var app = Application('Preview');
+        var app = Application('com.apple.Preview');
     } catch (e) {
         console.log(e);
         return false;

--- a/app/preview/preview_save_doc.applescript
+++ b/app/preview/preview_save_doc.applescript
@@ -1,7 +1,7 @@
 #!/usr/bin/env osascript -l JavaScript
 
 function preview_get_docs_info() {
-    app = Application('Preview');
+    app = Application('com.apple.Preview');
     var res = {};
     res[0] = [];
     for (i = 0; i < app.documents().length; i++) { // multiple windows


### PR DESCRIPTION
# Why
- 日本語 or 多言語でアプリケーション名を指定しても探せない
# How
- `Application()` はBundle IDでの指定も可能なので、third party appはそちらに統一する
